### PR TITLE
Feature/KOJO-36 | Make Kōjō more helpful when you make a mistake

### DIFF
--- a/Function42/.gitignore
+++ b/Function42/.gitignore
@@ -1,0 +1,3 @@
+!.gitignore
+.idea
+vendor/

--- a/Function42/README.md
+++ b/Function42/README.md
@@ -35,6 +35,8 @@
   gsub("working", "\033[1;33m&\033[0m"); 
   gsub("complete_success", "\033[1;32m&\033[0m"); 
   gsub("critical", "\033[5;101m&\033[0m"); 
+  gsub("Panicking", "\033[5;95m&\033[0m"); 
+  gsub("lucky", "\033[5;102m&\033[0m"); 
   print }';
   
  # After you see "working" events stop and a few "complete_success" then all messages have been deleted. Press ctrl+c

--- a/Function42/README.md
+++ b/Function42/README.md
@@ -36,7 +36,7 @@
   gsub("complete_success", "\033[1;32m&\033[0m"); 
   gsub("critical", "\033[5;101m&\033[0m"); 
   gsub("Panicking", "\033[5;95m&\033[0m"); 
-  gsub("lucky", "\033[5;102m&\033[0m"); 
+  gsub("TypeError", "\033[5;102m&\033[0m"); 
   print }';
   
  # After you see "working" events stop and a few "complete_success" then all messages have been deleted. Press ctrl+c

--- a/Function42/README.md
+++ b/Function42/README.md
@@ -1,0 +1,45 @@
+# Defines the fitness of Kōjō for
+ - Throw a TypeError deep in the worker and check that Kōjō logs useful info to indicate that fact
+ 
+ ## Setup Function42
+ 
+ ### Running Kōjō
+ Setting up the container:
+ 
+ Make sure you have pulled the latest version of Mason from Master
+ ```bash
+ git clone git@github.com:neighborhoods/KojoFitness.git;
+ cd KojoFitness;
+ git checkout 4.x;
+ git pull;
+ cd ../Mason;
+ docker-compose build --no-cache kojo_fitness nginx && docker-compose up -d;
+ 
+ # Create a database
+ touch data/pgsql/dumps/kojo_fitness.sql;  
+ docker-compose exec pgsql /docker-entrypoint-initdb.d/init.sh;
+ 
+ # Prepare Kōjō
+ docker-compose exec kojo_fitness bash -c 'cd Function42; composer install';
+ docker-compose exec kojo_fitness bash -c 'cd Function42; composer update';
+ docker-compose exec kojo_fitness bash -c 'cd Function42; ./vendor/bin/kojo db:setup:install $PWD/src/V1/Environment/';
+ docker-compose exec kojo_fitness bash -c 'cd Function42; php ./bin/setup-worker.php';
+ 
+ # Create messages for Kōjō to delete
+ docker-compose exec kojo_fitness bash -c 'cd Function42; php ./bin/create-messages.php';
+ 
+ # Run Kōjō to delete the messages and colorize the events
+ docker-compose exec kojo_fitness bash -c 'cd Function42; ./vendor/bin/kojo process:pool:server:start $PWD/src/V1/Environment/' |\
+  awk '{ 
+  gsub("new_worker", "\033[1;36m&\033[0m"); 
+  gsub("working", "\033[1;33m&\033[0m"); 
+  gsub("complete_success", "\033[1;32m&\033[0m"); 
+  gsub("critical", "\033[5;101m&\033[0m"); 
+  print }';
+  
+ # After you see "working" events stop and a few "complete_success" then all messages have been deleted. Press ctrl+c
+ 
+ # Delete the Kōjō Tables and clear redis
+ docker-compose exec kojo_fitness bash -c 'cd Function42; ./vendor/bin/kojo db:tear_down:uninstall $PWD/src/V1/Environment/';
+ docker-compose exec redis redis-cli flushall;
+ ```

--- a/Function42/bin/create-messages.php
+++ b/Function42/bin/create-messages.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+ini_set('assert.exception', '1');
+error_reporting(E_ALL);
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$client = \Aws\Sqs\SqsClient::factory(
+    ['region' => 'us-east-1']
+);
+
+$totalNumberOfMessagesToSend = 500;
+$messageCount = 0;
+while ($messageCount !== $totalNumberOfMessagesToSend) {
+    $client->sendMessage(array(
+        'QueueUrl' => 'https://sqs.us-east-1.amazonaws.com/272157948465/local-bwilson',
+        'MessageBody' => 'MESSAGE BODY',
+    ));
+
+    ++$messageCount;
+    if ($messageCount % 100 === 0){
+        echo "Wrote 100 messages to SQS, {$messageCount}/{$totalNumberOfMessagesToSend} in total\n";
+    }
+}
+
+return;

--- a/Function42/bin/setup-worker.php
+++ b/Function42/bin/setup-worker.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+error_reporting(E_ALL);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Symfony\Component\Finder\Finder;
+use Neighborhoods\Kojo\Api\V1\Job;
+
+$discoverableDirectories[] = __DIR__ . '/../src/V1/Environment';
+$finder = new Finder();
+$finder->name('*.yml');
+$finder->files()->in($discoverableDirectories);
+$jobCreator = (new Job\Type\Service())->addYmlServiceFinder($finder)->getNewJobTypeRegistrar();
+$jobCreator->setCode('protean_dlcp_example')
+    ->setWorkerClassUri(\Neighborhoods\KojoFitnessFunction42\V1\Worker\Facade::class)
+    ->setWorkerMethod('start')
+    ->setName('Protean DLCP Example')
+    ->setCronExpression('* * * * *')
+    ->setCanWorkInParallel(true)
+    ->setDefaultImportance(10)
+    ->setScheduleLimit(50)
+    ->setScheduleLimitAllowance(1)
+    ->setIsEnabled(true)
+    ->setAutoCompleteSuccess(false)
+    ->setAutoDeleteIntervalDuration('PT0S');
+$jobCreator->save();

--- a/Function42/composer.json
+++ b/Function42/composer.json
@@ -1,0 +1,40 @@
+{
+  "name": "neighborhoods/kojo-fitness",
+  "type": "library",
+  "description": "Neighborhoods Kōjō Examples provides example patterns for implementing Kōjō workers.",
+  "license": "MIT",
+  "keywords": [],
+  "authors": [
+    {
+      "name": "Brad Wilson",
+      "email": "brad.wilson@neighborhoods.com"
+    }
+  ],
+  "config": {
+    "sort-packages": true
+  },
+  "require": {
+    "php": ">=7.1",
+    "neighborhoods/kojo": "^3.0.0",
+    "aws/aws-sdk-php": "2.*"
+  },
+  "require-dev": {
+    "php": ">=7.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "Neighborhoods\\KojoFitnessFunction42\\": [
+        "src/",
+        "fab/"
+      ]
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Neighborhoods\\KojoFitnessFunction42\\": [
+        "test/",
+        "test-fab/"
+      ]
+    }
+  }
+}

--- a/Function42/composer.lock
+++ b/Function42/composer.lock
@@ -1,0 +1,1465 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "6328c0cc668bc24cb44c2d072a89c0c3",
+    "packages": [
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "2.8.31",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "64fa4b07f056e338a5f0f29eece75babaa83af68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/64fa4b07f056e338a5f0f29eece75babaa83af68",
+                "reference": "64fa4b07f056e338a5f0f29eece75babaa83af68",
+                "shasum": ""
+            },
+            "require": {
+                "guzzle/guzzle": "~3.7",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "doctrine/cache": "~1.0",
+                "ext-openssl": "*",
+                "monolog/monolog": "~1.4",
+                "phpunit/phpunit": "~4.0",
+                "phpunit/phpunit-mock-objects": "2.3.1",
+                "symfony/yaml": "~2.1"
+            },
+            "suggest": {
+                "doctrine/cache": "Adds support for caching of credentials and responses",
+                "ext-apc": "Allows service description opcode caching, request and response caching, and credentials caching",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "monolog/monolog": "Adds support for logging HTTP requests and responses",
+                "symfony/yaml": "Eases the ability to write manifests for creating jobs in AWS Import/Export"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Aws": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "http://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "http://aws.amazon.com/sdkforphp",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "time": "2016-07-25T18:03:20+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^4.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2018-08-21T18:01:43+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "5140a64c08b4b607b9bedaae0cedd26f04a0e621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/5140a64c08b4b607b9bedaae0cedd26f04a0e621",
+                "reference": "5140a64c08b4b607b9bedaae0cedd26f04a0e621",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "^1.0",
+                "doctrine/event-manager": "^1.0",
+                "ext-pdo": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^4.0",
+                "jetbrains/phpstorm-stubs": "^2018.1.2",
+                "phpstan/phpstan": "^0.10.1",
+                "phpunit/phpunit": "^7.1.2",
+                "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                "symfony/console": "^2.0.5|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev",
+                    "dev-develop": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2018-07-13T03:16:35+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^4.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Doctrine Event Manager component",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "eventdispatcher",
+                "eventmanager"
+            ],
+            "time": "2018-06-11T11:59:03+00:00"
+        },
+        {
+            "name": "dragonmantank/cron-expression",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dragonmantank/cron-expression.git",
+                "reference": "92a2c3768d50e21a1f26a53cb795ce72806266c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/92a2c3768d50e21a1f26a53cb795ce72806266c5",
+                "reference": "92a2c3768d50e21a1f26a53cb795ce72806266c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cron\\": "src/Cron/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Chris Tankersley",
+                    "email": "chris@ctankersley.com",
+                    "homepage": "https://github.com/dragonmantank"
+                }
+            ],
+            "description": "CRON for PHP: Calculate the next or previous run date and determine if a CRON expression is due",
+            "keywords": [
+                "cron",
+                "schedule"
+            ],
+            "time": "2018-06-06T03:12:17+00:00"
+        },
+        {
+            "name": "guzzle/guzzle",
+            "version": "v3.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle3.git",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=5.3.3",
+                "symfony/event-dispatcher": "~2.1"
+            },
+            "replace": {
+                "guzzle/batch": "self.version",
+                "guzzle/cache": "self.version",
+                "guzzle/common": "self.version",
+                "guzzle/http": "self.version",
+                "guzzle/inflection": "self.version",
+                "guzzle/iterator": "self.version",
+                "guzzle/log": "self.version",
+                "guzzle/parser": "self.version",
+                "guzzle/plugin": "self.version",
+                "guzzle/plugin-async": "self.version",
+                "guzzle/plugin-backoff": "self.version",
+                "guzzle/plugin-cache": "self.version",
+                "guzzle/plugin-cookie": "self.version",
+                "guzzle/plugin-curlauth": "self.version",
+                "guzzle/plugin-error-response": "self.version",
+                "guzzle/plugin-history": "self.version",
+                "guzzle/plugin-log": "self.version",
+                "guzzle/plugin-md5": "self.version",
+                "guzzle/plugin-mock": "self.version",
+                "guzzle/plugin-oauth": "self.version",
+                "guzzle/service": "self.version",
+                "guzzle/stream": "self.version"
+            },
+            "require-dev": {
+                "doctrine/cache": "~1.3",
+                "monolog/monolog": "~1.0",
+                "phpunit/phpunit": "3.7.*",
+                "psr/log": "~1.0",
+                "symfony/class-loader": "~2.1",
+                "zendframework/zend-cache": "2.*,<2.3",
+                "zendframework/zend-log": "2.*,<2.3"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Guzzle 5 has moved to a new package name. The package you have installed, Guzzle 3, is deprecated."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Guzzle": "src/",
+                    "Guzzle\\Tests": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Guzzle Community",
+                    "homepage": "https://github.com/guzzle/guzzle/contributors"
+                }
+            ],
+            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "abandoned": "guzzlehttp/guzzle",
+            "time": "2015-03-18T18:23:50+00:00"
+        },
+        {
+            "name": "neighborhoods/kojo",
+            "version": "3.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/neighborhoods/kojo.git",
+                "reference": "c6aec7e0d3ed31c765f0c3faa7d2781e80b4aa6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/neighborhoods/kojo/zipball/c6aec7e0d3ed31c765f0c3faa7d2781e80b4aa6b",
+                "reference": "c6aec7e0d3ed31c765f0c3faa7d2781e80b4aa6b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^2.7",
+                "dragonmantank/cron-expression": "^2.0",
+                "php": ">=7.1",
+                "symfony/cache": "^4.0",
+                "symfony/config": "^4.0",
+                "symfony/console": "^4.0",
+                "symfony/dependency-injection": "^4.0",
+                "symfony/expression-language": "^4.0",
+                "symfony/filesystem": "^4.0",
+                "symfony/finder": "^4.0",
+                "symfony/yaml": "^4.0",
+                "zendframework/zend-db": "^2.8"
+            },
+            "require-dev": {
+                "phpunit/dbunit": "^4.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "bin": [
+                "bin/kojo",
+                "scaffolding/bin/scaffolding.php"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Neighborhoods\\Kojo\\": "src",
+                    "Neighborhoods\\Scaffolding\\": "scaffolding/src",
+                    "Neighborhoods\\Pylon\\": "pylon/src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brad Wilson",
+                    "email": "brad.wilson@neighborhoods.com"
+                }
+            ],
+            "description": "Neighborhoods Kōjō is a distributed task manager.",
+            "time": "2018-07-26T20:16:54+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "symfony/cache",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "05ce0ddc8bc1ffe592105398fc2c725cb3080a38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/05ce0ddc8bc1ffe592105398fc2c725cb3080a38",
+                "reference": "05ce0ddc8bc1ffe592105398fc2c725cb3080a38",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/cache": "~1.0",
+                "psr/log": "~1.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "conflict": {
+                "symfony/var-dumper": "<3.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/cache": "~1.6",
+                "doctrine/dbal": "~2.4",
+                "predis/predis": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Cache component with PSR-6, PSR-16, and tags",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "time": "2018-09-30T03:38:13+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "b3d4d7b567d7a49e6dfafb6d4760abc921177c96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/b3d4d7b567d7a49e6dfafb6d4760abc921177c96",
+                "reference": "b3d4d7b567d7a49e6dfafb6d4760abc921177c96",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/filesystem": "~3.4|~4.0",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<3.4"
+            },
+            "require-dev": {
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/finder": "~3.4|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-09-08T13:24:10+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "dc7122fe5f6113cfaba3b3de575d31112c9aa60b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/dc7122fe5f6113cfaba3b3de575d31112c9aa60b",
+                "reference": "dc7122fe5f6113cfaba3b3de575d31112c9aa60b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0"
+            },
+            "suggest": {
+                "psr/log-implementation": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-10-03T08:15:46+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "f6b9d893ad28aefd8942dc0469c8397e2216fe30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f6b9d893ad28aefd8942dc0469c8397e2216fe30",
+                "reference": "f6b9d893ad28aefd8942dc0469c8397e2216fe30",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "symfony/config": "<4.1.1",
+                "symfony/finder": "<3.4",
+                "symfony/proxy-manager-bridge": "<3.4",
+                "symfony/yaml": "<3.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.0"
+            },
+            "require-dev": {
+                "symfony/config": "~4.1",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/expression-language": "For using expressions in service container configuration",
+                "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-10-02T12:40:59+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.8.46",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "84ae343f39947aa084426ed1138bb96bf94d1f12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/84ae343f39947aa084426ed1138bb96bf94d1f12",
+                "reference": "84ae343f39947aa084426ed1138bb96bf94d1f12",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^2.0.5|~3.0.0",
+                "symfony/dependency-injection": "~2.6|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/stopwatch": "~2.3|~3.0.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-07-26T09:03:18+00:00"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "065bba63c61c96fd2d4fbd01b28de058e6f8779a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/065bba63c61c96fd2d4fbd01b28de058e6f8779a",
+                "reference": "065bba63c61c96fd2d4fbd01b28de058e6f8779a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/cache": "~3.4|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ExpressionLanguage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ExpressionLanguage Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-07-26T09:10:45+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "596d12b40624055c300c8b619755b748ca5cf0b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/596d12b40624055c300c8b619755b748ca5cf0b5",
+                "reference": "596d12b40624055c300c8b619755b748ca5cf0b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-10-02T12:40:59+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "1f17195b44543017a9c9b2d437c670627e96ad06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/1f17195b44543017a9c9b2d437c670627e96ad06",
+                "reference": "1f17195b44543017a9c9b2d437c670627e96ad06",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-10-03T08:47:56+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/367e689b2fdc19965be435337b50bc8adf2746c9",
+                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-10-02T16:36:10+00:00"
+        },
+        {
+            "name": "zendframework/zend-db",
+            "version": "2.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-db.git",
+                "reference": "5b4f2c42f94c9f7f4b2f456a0ebe459fab12b3d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-db/zipball/5b4f2c42f94c9f7f4b2f456a0ebe459fab12b3d9",
+                "reference": "5b4f2c42f94c9f7f4b2f456a0ebe459fab12b3d9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+                "zendframework/zend-hydrator": "^1.1 || ^2.1",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
+            },
+            "suggest": {
+                "zendframework/zend-eventmanager": "Zend\\EventManager component",
+                "zendframework/zend-hydrator": "Zend\\Hydrator component for using HydratingResultSets",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev",
+                    "dev-develop": "2.10-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Db",
+                    "config-provider": "Zend\\Db\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Db\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Database abstraction layer, SQL abstraction, result set abstraction, and RowDataGateway and TableDataGateway implementations",
+            "keywords": [
+                "ZendFramework",
+                "db",
+                "zf"
+            ],
+            "time": "2018-04-09T13:21:36+00:00"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/66536006722aff9e62d1b331025089b7ec71c065",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "keywords": [
+                "ZendFramework",
+                "stdlib",
+                "zf"
+            ],
+            "time": "2018-08-28T21:34:05+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.1"
+    },
+    "platform-dev": {
+        "php": ">=7.1"
+    }
+}

--- a/Function42/fab/V1/Aws/Sqs/SqsClient.yml
+++ b/Function42/fab/V1/Aws/Sqs/SqsClient.yml
@@ -1,0 +1,10 @@
+parameters:
+  v1.aws.sqs.sqs_client.region: '%env(SQS_REGION)%'
+services:
+  v1.aws.sqs.sqs_client:
+    class: Aws\Sqs\SqsClient
+    public: false
+    shared: false
+    factory: [Aws\Sqs\SqsClient, factory]
+    arguments:
+    - region: '%v1.aws.sqs.sqs_client.region%'

--- a/Function42/fab/V1/Aws/Sqs/SqsClient/AwareTrait.php
+++ b/Function42/fab/V1/Aws/Sqs/SqsClient/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Aws\Sqs\SqsClient;
+
+use Aws\Sqs\SqsClient;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $AwsSqsSqsClient;
+
+    public function setV1AwsSqsSqsClient(SqsClient $awsSqsSqsClient): self
+    {
+        if ($this->hasV1AwsSqsSqsClient()) {
+            throw new \LogicException('AwsSqsSqsClient is already set.');
+        }
+        $this->AwsSqsSqsClient = $awsSqsSqsClient;
+
+        return $this;
+    }
+
+    protected function getV1AwsSqsSqsClient(): SqsClient
+    {
+        if (!$this->hasV1AwsSqsSqsClient()) {
+            throw new \LogicException('AwsSqsSqsClient is not set.');
+        }
+
+        return $this->AwsSqsSqsClient;
+    }
+
+    protected function hasV1AwsSqsSqsClient(): bool
+    {
+        return isset($this->AwsSqsSqsClient);
+    }
+
+    protected function unsetV1AwsSqsSqsClient(): self
+    {
+        if (!$this->hasV1AwsSqsSqsClient()) {
+            throw new \LogicException('AwsSqsSqsClient is not set.');
+        }
+        unset($this->AwsSqsSqsClient);
+
+        return $this;
+    }
+}

--- a/Function42/fab/V1/Guzzle/Service/Resource/Model/AwareTrait.php
+++ b/Function42/fab/V1/Guzzle/Service/Resource/Model/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Guzzle\Service\Resource\Model;
+
+use Guzzle\Service\Resource\Model;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $GuzzleServiceResourceModel;
+
+    public function setGuzzleServiceResourceModel(Model $guzzleServiceResourceModel): self
+    {
+        if ($this->hasGuzzleServiceResourceModel()) {
+            throw new \LogicException('GuzzleServiceResourceModel is already set.');
+        }
+        $this->GuzzleServiceResourceModel = $guzzleServiceResourceModel;
+
+        return $this;
+    }
+
+    protected function getGuzzleServiceResourceModel(): Model
+    {
+        if (!$this->hasGuzzleServiceResourceModel()) {
+            throw new \LogicException('GuzzleServiceResourceModel is not set.');
+        }
+
+        return $this->GuzzleServiceResourceModel;
+    }
+
+    protected function hasGuzzleServiceResourceModel(): bool
+    {
+        return isset($this->GuzzleServiceResourceModel);
+    }
+
+    protected function unsetGuzzleServiceResourceModel(): self
+    {
+        if (!$this->hasGuzzleServiceResourceModel()) {
+            throw new \LogicException('GuzzleServiceResourceModel is not set.');
+        }
+        unset($this->GuzzleServiceResourceModel);
+
+        return $this;
+    }
+}

--- a/Function42/fab/V1/Worker/Delegate/AwareTrait.php
+++ b/Function42/fab/V1/Worker/Delegate/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\DelegateInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoExamplesV1WorkerDelegate;
+
+    public function setV1WorkerDelegate(DelegateInterface $v1WorkerDelegate): self
+    {
+        if ($this->hasV1WorkerDelegate()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerDelegate is already set.');
+        }
+        $this->NeighborhoodsKojoExamplesV1WorkerDelegate = $v1WorkerDelegate;
+
+        return $this;
+    }
+
+    protected function getV1WorkerDelegate(): DelegateInterface
+    {
+        if (!$this->hasV1WorkerDelegate()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerDelegate is not set.');
+        }
+
+        return $this->NeighborhoodsKojoExamplesV1WorkerDelegate;
+    }
+
+    protected function hasV1WorkerDelegate(): bool
+    {
+        return isset($this->NeighborhoodsKojoExamplesV1WorkerDelegate);
+    }
+
+    protected function unsetV1WorkerDelegate(): self
+    {
+        if (!$this->hasV1WorkerDelegate()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerDelegate is not set.');
+        }
+        unset($this->NeighborhoodsKojoExamplesV1WorkerDelegate);
+
+        return $this;
+    }
+}

--- a/Function42/fab/V1/Worker/Delegate/Factory.php
+++ b/Function42/fab/V1/Worker/Delegate/Factory.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\DelegateInterface;
+
+/** @codeCoverageIgnore */
+class Factory implements FactoryInterface
+{
+    use AwareTrait;
+
+    public function create(): DelegateInterface
+    {
+        return clone $this->getV1WorkerDelegate();
+    }
+}

--- a/Function42/fab/V1/Worker/Delegate/Factory.yml
+++ b/Function42/fab/V1/Worker/Delegate/Factory.yml
@@ -1,0 +1,7 @@
+services:
+  neighborhoods.v1.worker.delegate.factory:
+    class: Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate\Factory
+    public: false
+    shared: true
+    calls:
+        - [setV1WorkerDelegate, ['@neighborhoods.v1.worker.delegate']]

--- a/Function42/fab/V1/Worker/Delegate/Factory/AwareTrait.php
+++ b/Function42/fab/V1/Worker/Delegate/Factory/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate\Factory;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate\FactoryInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoExamplesV1WorkerDelegateFactory;
+
+    public function setV1WorkerDelegateFactory(FactoryInterface $v1WorkerDelegateFactory): self
+    {
+        if ($this->hasV1WorkerDelegateFactory()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerDelegateFactory is already set.');
+        }
+        $this->NeighborhoodsKojoExamplesV1WorkerDelegateFactory = $v1WorkerDelegateFactory;
+
+        return $this;
+    }
+
+    protected function getV1WorkerDelegateFactory(): FactoryInterface
+    {
+        if (!$this->hasV1WorkerDelegateFactory()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerDelegateFactory is not set.');
+        }
+
+        return $this->NeighborhoodsKojoExamplesV1WorkerDelegateFactory;
+    }
+
+    protected function hasV1WorkerDelegateFactory(): bool
+    {
+        return isset($this->NeighborhoodsKojoExamplesV1WorkerDelegateFactory);
+    }
+
+    protected function unsetV1WorkerDelegateFactory(): self
+    {
+        if (!$this->hasV1WorkerDelegateFactory()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerDelegateFactory is not set.');
+        }
+        unset($this->NeighborhoodsKojoExamplesV1WorkerDelegateFactory);
+
+        return $this;
+    }
+}

--- a/Function42/fab/V1/Worker/Delegate/FactoryInterface.php
+++ b/Function42/fab/V1/Worker/Delegate/FactoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\DelegateInterface;
+
+interface FactoryInterface
+{
+    public function create(): DelegateInterface;
+}

--- a/Function42/fab/V1/Worker/Delegate/Repository/AwareTrait.php
+++ b/Function42/fab/V1/Worker/Delegate/Repository/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate\Repository;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate\RepositoryInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoExamplesV1WorkerDelegateRepository;
+
+    public function setV1WorkerDelegateRepository(RepositoryInterface $v1WorkerDelegateRepository): self
+    {
+        if ($this->hasV1WorkerDelegateRepository()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerDelegateRepository is already set.');
+        }
+        $this->NeighborhoodsKojoExamplesV1WorkerDelegateRepository = $v1WorkerDelegateRepository;
+
+        return $this;
+    }
+
+    protected function getV1WorkerDelegateRepository(): RepositoryInterface
+    {
+        if (!$this->hasV1WorkerDelegateRepository()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerDelegateRepository is not set.');
+        }
+
+        return $this->NeighborhoodsKojoExamplesV1WorkerDelegateRepository;
+    }
+
+    protected function hasV1WorkerDelegateRepository(): bool
+    {
+        return isset($this->NeighborhoodsKojoExamplesV1WorkerDelegateRepository);
+    }
+
+    protected function unsetV1WorkerDelegateRepository(): self
+    {
+        if (!$this->hasV1WorkerDelegateRepository()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerDelegateRepository is not set.');
+        }
+        unset($this->NeighborhoodsKojoExamplesV1WorkerDelegateRepository);
+
+        return $this;
+    }
+}

--- a/Function42/fab/V1/Worker/Queue/AwareTrait.php
+++ b/Function42/fab/V1/Worker/Queue/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\QueueInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoExamplesV1WorkerQueue;
+
+    public function setV1WorkerQueue(QueueInterface $v1WorkerQueue): self
+    {
+        if ($this->hasV1WorkerQueue()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerQueue is already set.');
+        }
+        $this->NeighborhoodsKojoExamplesV1WorkerQueue = $v1WorkerQueue;
+
+        return $this;
+    }
+
+    protected function getV1WorkerQueue(): QueueInterface
+    {
+        if (!$this->hasV1WorkerQueue()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerQueue is not set.');
+        }
+
+        return $this->NeighborhoodsKojoExamplesV1WorkerQueue;
+    }
+
+    protected function hasV1WorkerQueue(): bool
+    {
+        return isset($this->NeighborhoodsKojoExamplesV1WorkerQueue);
+    }
+
+    protected function unsetV1WorkerQueue(): self
+    {
+        if (!$this->hasV1WorkerQueue()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerQueue is not set.');
+        }
+        unset($this->NeighborhoodsKojoExamplesV1WorkerQueue);
+
+        return $this;
+    }
+}

--- a/Function42/fab/V1/Worker/Queue/Message/AwareTrait.php
+++ b/Function42/fab/V1/Worker/Queue/Message/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\Message;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\MessageInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoExamplesV1WorkerQueueMessage;
+
+    public function setV1WorkerQueueMessage(MessageInterface $v1WorkerQueueMessage): self
+    {
+        if ($this->hasV1WorkerQueueMessage()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerQueueMessage is already set.');
+        }
+        $this->NeighborhoodsKojoExamplesV1WorkerQueueMessage = $v1WorkerQueueMessage;
+
+        return $this;
+    }
+
+    protected function getV1WorkerQueueMessage(): MessageInterface
+    {
+        if (!$this->hasV1WorkerQueueMessage()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerQueueMessage is not set.');
+        }
+
+        return $this->NeighborhoodsKojoExamplesV1WorkerQueueMessage;
+    }
+
+    protected function hasV1WorkerQueueMessage(): bool
+    {
+        return isset($this->NeighborhoodsKojoExamplesV1WorkerQueueMessage);
+    }
+
+    protected function unsetV1WorkerQueueMessage(): self
+    {
+        if (!$this->hasV1WorkerQueueMessage()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerQueueMessage is not set.');
+        }
+        unset($this->NeighborhoodsKojoExamplesV1WorkerQueueMessage);
+
+        return $this;
+    }
+}

--- a/Function42/fab/V1/Worker/Queue/Message/Factory.php
+++ b/Function42/fab/V1/Worker/Queue/Message/Factory.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\Message;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\MessageInterface;
+
+
+/** @codeCoverageIgnore */
+class Factory implements FactoryInterface
+{
+    use AwareTrait;
+
+
+    public function create(): MessageInterface
+    {
+        return clone $this->getV1WorkerQueueMessage();
+    }
+}

--- a/Function42/fab/V1/Worker/Queue/Message/Factory.yml
+++ b/Function42/fab/V1/Worker/Queue/Message/Factory.yml
@@ -1,0 +1,7 @@
+services:
+  neighborhoods.v1.worker.queue.message.factory:
+    class: Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\Message\Factory
+    public: false
+    shared: true
+    calls:
+      - [setV1WorkerQueueMessage, ['@v1.worker.queue.message']]

--- a/Function42/fab/V1/Worker/Queue/Message/Factory/AwareTrait.php
+++ b/Function42/fab/V1/Worker/Queue/Message/Factory/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\Message\Factory;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\Message\FactoryInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoExamplesV1WorkerQueueMessageFactory;
+
+    public function setV1WorkerQueueMessageFactory(FactoryInterface $v1WorkerQueueMessageFactory): self
+    {
+        if ($this->hasV1WorkerQueueMessageFactory()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerQueueMessageFactory is already set.');
+        }
+        $this->NeighborhoodsKojoExamplesV1WorkerQueueMessageFactory = $v1WorkerQueueMessageFactory;
+
+        return $this;
+    }
+
+    protected function getV1WorkerQueueMessageFactory(): FactoryInterface
+    {
+        if (!$this->hasV1WorkerQueueMessageFactory()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerQueueMessageFactory is not set.');
+        }
+
+        return $this->NeighborhoodsKojoExamplesV1WorkerQueueMessageFactory;
+    }
+
+    protected function hasV1WorkerQueueMessageFactory(): bool
+    {
+        return isset($this->NeighborhoodsKojoExamplesV1WorkerQueueMessageFactory);
+    }
+
+    protected function unsetV1WorkerQueueMessageFactory(): self
+    {
+        if (!$this->hasV1WorkerQueueMessageFactory()) {
+            throw new \LogicException('NeighborhoodsKojoExamplesV1WorkerQueueMessageFactory is not set.');
+        }
+        unset($this->NeighborhoodsKojoExamplesV1WorkerQueueMessageFactory);
+
+        return $this;
+    }
+}

--- a/Function42/fab/V1/Worker/Queue/Message/FactoryInterface.php
+++ b/Function42/fab/V1/Worker/Queue/Message/FactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\Message;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\MessageInterface;
+
+/** @codeCoverageIgnore */
+interface FactoryInterface
+{
+    public function create(): MessageInterface;
+}

--- a/Function42/fab/V1/Worker/Queue/MessageArray.php
+++ b/Function42/fab/V1/Worker/Queue/MessageArray.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue;
+
+/** @codeCoverageIgnore */
+class MessageArray extends \ArrayIterator implements MessageArrayInterface
+{
+    /** @param MessageInterface ...$workerQueueMessages */
+    public function __construct(array $workerQueueMessages = array(), int $flags = 0)
+    {
+        if (!empty($workerQueueMessages)) {
+            $this->_assertValidArrayType(...$workerQueueMessages);
+        }
+
+        parent::__construct($workerQueueMessages, $flags);
+    }
+
+    public function offsetGet($index): MessageInterface
+    {
+        return $this->_assertValidArrayItemType(parent::offsetGet($index));
+    }
+
+    /** @param MessageInterface $workerQueueMessage */
+    public function offsetSet($index, $workerQueueMessage)
+    {
+        parent::offsetSet($index, $this->_assertValidArrayItemType($workerQueueMessage));
+    }
+
+    /** @param MessageInterface $workerQueueMessage */
+    public function append($workerQueueMessage)
+    {
+        $this->_assertValidArrayItemType($workerQueueMessage);
+        parent::append($workerQueueMessage);
+    }
+
+    public function current(): MessageInterface
+    {
+        return parent::current();
+    }
+
+    protected function _assertValidArrayItemType(MessageInterface $workerQueueMessage)
+    {
+        return $workerQueueMessage;
+    }
+
+    protected function _assertValidArrayType(MessageInterface ...$workerQueueMessages): MessageArrayInterface
+    {
+        return $this;
+    }
+
+    public function getArrayCopy(): MessageArrayInterface
+    {
+        return new self(parent::getArrayCopy(), (int)$this->getFlags());
+    }
+}

--- a/Function42/fab/V1/Worker/Queue/MessageArrayInterface.php
+++ b/Function42/fab/V1/Worker/Queue/MessageArrayInterface.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue;
+
+/** @codeCoverageIgnore */
+interface MessageArrayInterface extends \SeekableIterator, \ArrayAccess, \Serializable, \Countable
+{
+    /** @param MessageInterface ...$workerQueueMessages */
+    public function __construct(array $workerQueueMessages = array(), int $flags = 0);
+
+    public function offsetGet($index): MessageInterface;
+
+    /** @param MessageInterface $workerQueueMessage */
+    public function offsetSet($index, $workerQueueMessage);
+
+    /** @param MessageInterface $workerQueueMessage */
+    public function append($workerQueueMessage);
+
+    public function current(): MessageInterface;
+
+    public function getArrayCopy(): MessageArrayInterface;
+}

--- a/Function42/src/V1/Environment/Parameters.yml
+++ b/Function42/src/V1/Environment/Parameters.yml
@@ -1,0 +1,10 @@
+parameters:
+# Redis.
+  neighborhoods.kojo.environment.parameters.redis_port: '%env(KOJO_REDIS_PORT)%'
+  neighborhoods.kojo.environment.parameters.redis_host: '%env(KOJO_REDIS_HOST)%'
+# DB
+  neighborhoods.kojo.environment.parameters.database_user_name: '%env(DATABASE_USERNAME)%'
+  neighborhoods.kojo.environment.parameters.database_password: '%env(DATABASE_PASSWORD)%'
+  neighborhoods.kojo.environment.parameters.database_adapter: '%env(DATABASE_ADAPTER)%'
+  neighborhoods.kojo.environment.parameters.database_host: '%env(DATABASE_HOST)%'
+  neighborhoods.kojo.environment.parameters.database_name: '%env(DATABASE_NAME)%'

--- a/Function42/src/V1/Worker.php
+++ b/Function42/src/V1/Worker.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1;
+
+use Neighborhoods\Kojo\Api;
+
+class Worker implements WorkerInterface
+{
+    use Worker\Delegate\Repository\AwareTrait;
+    use Api\V1\Worker\Service\AwareTrait;
+    use Worker\Queue\AwareTrait;
+    public const JOB_TYPE_CODE = 'protean_dlcp_example';
+
+    public function work() : WorkerInterface
+    {
+        $this->fireEvent('new_worker');
+        if ($this->getApiV1WorkerService()->getTimesCrashed() === 0 && $this->getV1WorkerQueue()->hasNextMessage()) {
+            // Wait for one message to become available.
+            $this->fireEvent('message_received');
+            // Schedule another kōjō job of the same type.
+            $this->_scheduleNextJob();
+
+            // Delegate the work for the first message.
+            $this->_delegateWork();
+
+            // Delegate the work until the observed Queue is empty.
+            while ($this->getV1WorkerQueue()->hasNextMessage()) {
+                $this->_delegateWork();
+            }
+
+        }
+
+        // Tell Kōjō that we are done and all is well.
+        $this->fireEvent('complete_success');
+        $this->getApiV1WorkerService()->requestCompleteSuccess()->applyRequest();
+
+        // Fluent interfaces for the love of Pete.
+        return $this;
+    }
+
+    protected function _delegateWork() : WorkerInterface
+    {
+        $workerDelegate = $this->getV1WorkerDelegateRepository()->getV1NewWorkerDelegate();
+        $workerDelegate->setV1WorkerQueueMessage($this->getV1WorkerQueue()->getNextMessage());
+
+        $this->fireEvent('working');
+        if (extension_loaded('newrelic')) {
+            newrelic_end_transaction();
+            newrelic_start_transaction(ini_get("newrelic.appname")); // start recording a new transaction
+            newrelic_name_transaction(self::JOB_TYPE_CODE);
+        }
+
+        $workerDelegate->businessLogic();
+
+        return $this;
+    }
+
+    protected function _scheduleNextJob() : WorkerInterface
+    {
+        $this->fireEvent('schedule_next_job');
+        $newJobScheduler = $this->getApiV1WorkerService()->getNewJobScheduler();
+        $newJobScheduler->setJobTypeCode(self::JOB_TYPE_CODE)
+            ->setWorkAtDateTime(new \DateTime('now'))
+            ->save();
+
+        return $this;
+    }
+
+    protected function fireEvent(string $event) : WorkerInterface
+    {
+        if (extension_loaded('newrelic')) {
+            newrelic_record_custom_event($event, ['job_type' => self::JOB_TYPE_CODE]);
+        }
+        $this->getApiV1WorkerService()->getLogger()->info($event, ['job_type' => self::JOB_TYPE_CODE]);
+
+        return $this;
+    }
+}

--- a/Function42/src/V1/Worker.yml
+++ b/Function42/src/V1/Worker.yml
@@ -1,0 +1,8 @@
+services:
+  Neighborhoods\KojoFitnessFunction42\V1\WorkerInterface:
+    class: Neighborhoods\KojoFitnessFunction42\V1\Worker
+    public: true
+    shared: false
+    calls:
+      - [setV1WorkerDelegateRepository, ['@neighborhoods.v1.worker.delegate.repository']]
+      - [setV1WorkerQueue, ['@neighborhoods.v1.worker.queue']]

--- a/Function42/src/V1/Worker/Delegate.php
+++ b/Function42/src/V1/Worker/Delegate.php
@@ -14,9 +14,13 @@ class Delegate implements DelegateInterface
         if ((bool)random_int(0, 1)) {
             $this->getV1WorkerQueueMessage()->delete();
         } else {
-            throw new \TypeError("Didn't get lucky");
+            $this->onlyTakesIntegers('Not very lucky');
         }
 
         return $this;
+    }
+
+    public function onlyTakesIntegers(int $number){
+        return $number;
     }
 }

--- a/Function42/src/V1/Worker/Delegate.php
+++ b/Function42/src/V1/Worker/Delegate.php
@@ -9,9 +9,13 @@ class Delegate implements DelegateInterface
 {
     use Worker\Queue\Message\AwareTrait;
 
-    public function businessLogic(): DelegateInterface
+    public function businessLogic() : DelegateInterface
     {
-        $this->getV1WorkerQueueMessage()->delete();
+        if ((bool)random_int(0, 1)) {
+            $this->getV1WorkerQueueMessage()->delete();
+        } else {
+            throw new \TypeError("Didn't get lucky");
+        }
 
         return $this;
     }

--- a/Function42/src/V1/Worker/Delegate.php
+++ b/Function42/src/V1/Worker/Delegate.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker;
+
+class Delegate implements DelegateInterface
+{
+    use Worker\Queue\Message\AwareTrait;
+
+    public function businessLogic(): DelegateInterface
+    {
+        $this->getV1WorkerQueueMessage()->delete();
+
+        return $this;
+    }
+}

--- a/Function42/src/V1/Worker/Delegate.yml
+++ b/Function42/src/V1/Worker/Delegate.yml
@@ -1,0 +1,5 @@
+services:
+  neighborhoods.v1.worker.delegate:
+    class: Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate
+    public: false
+    shared: false

--- a/Function42/src/V1/Worker/Delegate/Repository.php
+++ b/Function42/src/V1/Worker/Delegate/Repository.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\DelegateInterface;
+use Neighborhoods\KojoFitnessFunction42\V1\Worker;
+
+class Repository implements RepositoryInterface
+{
+    use Worker\Delegate\Factory\AwareTrait;
+
+    public function getV1NewWorkerDelegate(): DelegateInterface
+    {
+        return $this->getV1WorkerDelegateFactory()->create();
+    }
+}

--- a/Function42/src/V1/Worker/Delegate/Repository.yml
+++ b/Function42/src/V1/Worker/Delegate/Repository.yml
@@ -1,0 +1,7 @@
+services:
+  neighborhoods.v1.worker.delegate.repository:
+    class: Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate\Repository
+    public: false
+    shared: true
+    calls:
+      - [setV1WorkerDelegateFactory, ['@neighborhoods.v1.worker.delegate.factory']]

--- a/Function42/src/V1/Worker/Delegate/RepositoryInterface.php
+++ b/Function42/src/V1/Worker/Delegate/RepositoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Delegate;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\DelegateInterface;
+
+interface RepositoryInterface
+{
+    public function getV1NewWorkerDelegate(): DelegateInterface;
+}

--- a/Function42/src/V1/Worker/DelegateInterface.php
+++ b/Function42/src/V1/Worker/DelegateInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\MessageInterface;
+
+interface DelegateInterface
+{
+    public function setV1WorkerQueueMessage(MessageInterface $workerQueueMessage);
+
+    public function businessLogic(): DelegateInterface;
+}

--- a/Function42/src/V1/Worker/Facade.php
+++ b/Function42/src/V1/Worker/Facade.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker;
+
+use Neighborhoods\Pylon\DependencyInjection;
+use Neighborhoods\Kojo\Api;
+use Neighborhoods\KojoFitnessFunction42\V1\WorkerInterface;
+use Symfony\Component\Finder\Finder;
+
+class Facade implements FacadeInterface
+{
+    use Api\V1\Worker\Service\AwareTrait;
+    protected $containerBuilderFacade;
+    protected $worker;
+    protected $isBootStrapped = false;
+
+    public function start(): FacadeInterface
+    {
+        $this->bootstrap();
+        $this->getWorker()->work();
+
+        return $this;
+    }
+
+    protected function bootstrap(): FacadeInterface
+    {
+        if ($this->isBootStrapped !== false) {
+            throw new \LogicException('Worker facade is already bootstrapped.');
+        }
+
+        $discoverableDirectories[] = __DIR__ . '/../../../src';
+        $discoverableDirectories[] = __DIR__ . '/../../../fab';
+        $finder = new Finder();
+        $finder->name('*.yml');
+        $finder->files()->in($discoverableDirectories);
+        $this->getContainerBuilderFacade()->addFinder($finder);
+        $containerBuilder = $this->getContainerBuilderFacade()->getContainerBuilder();
+        $this->setWorker($containerBuilder->get(WorkerInterface::class));
+        $this->isBootStrapped = true;
+
+        return $this;
+    }
+
+    public function getContainerBuilderFacade(): DependencyInjection\ContainerBuilder\FacadeInterface
+    {
+        if ($this->containerBuilderFacade === null) {
+            $this->containerBuilderFacade = new DependencyInjection\ContainerBuilder\Facade();
+        }
+
+        return $this->containerBuilderFacade;
+    }
+
+    protected function getWorker(): WorkerInterface
+    {
+        if ($this->worker === null) {
+            throw new \LogicException('Worker is not set.');
+        }
+
+        return $this->worker;
+    }
+
+    protected function setWorker(WorkerInterface $worker): FacadeInterface
+    {
+        if ($this->worker !== null) {
+            throw new \LogicException('Worker is already set.');
+        }
+        $this->worker = $worker->setApiV1WorkerService($this->getApiV1WorkerService());
+
+        return $this;
+    }
+}

--- a/Function42/src/V1/Worker/FacadeInterface.php
+++ b/Function42/src/V1/Worker/FacadeInterface.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker;
+
+interface FacadeInterface
+{
+    public function start(): FacadeInterface;
+}

--- a/Function42/src/V1/Worker/Queue.php
+++ b/Function42/src/V1/Worker/Queue.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker;
+
+use Guzzle\Service\Resource\Model;
+use Neighborhoods\KojoFitnessFunction42\V1;
+use Neighborhoods\KojoFitnessFunction42\V1\Aws;
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\MessageInterface;
+
+class Queue implements QueueInterface
+{
+    use V1\Worker\Queue\Message\Factory\AwareTrait;
+    use V1\Worker\Queue\Message\AwareTrait;
+    use Aws\Sqs\SqsClient\AwareTrait;
+
+    protected $queueUrl;
+
+    protected const QUEUE_URL = 'QueueUrl';
+    protected const MESSAGES = 'Messages';
+
+    protected const WAIT_TIME_SECONDS = 'WaitTimeSeconds';
+
+    public function getNextMessage(): MessageInterface
+    {
+        $v1WorkerQueueMessage = $this->getV1WorkerQueueMessage();
+        $this->unsetV1WorkerQueueMessage();
+
+        return $v1WorkerQueueMessage;
+    }
+
+    public function waitForNextMessage(): QueueInterface
+    {
+        $guzzleServiceResourceModel = $this->receiveMessage();
+        while ($guzzleServiceResourceModel->get(self::MESSAGES) === null) {
+            $guzzleServiceResourceModel = $this->receiveMessage();
+        }
+        $this->createNextMessage($guzzleServiceResourceModel);
+
+        return $this;
+    }
+
+    public function hasNextMessage(): bool
+    {
+        if (!$this->hasV1WorkerQueueMessage()) {
+            $guzzleServiceResourceModel = $this->receiveMessage();
+            if ($guzzleServiceResourceModel->get(self::MESSAGES) !== null) {
+                $this->createNextMessage($guzzleServiceResourceModel);
+            }
+        }
+
+        return $this->hasV1WorkerQueueMessage();
+    }
+
+    protected function createNextMessage(Model $guzzleServiceResourceModel): QueueInterface
+    {
+        $v1WorkerQueueMessage = $this->getV1WorkerQueueMessageFactory()->create();
+        $v1WorkerQueueMessage->setGuzzleServiceResourceModel($guzzleServiceResourceModel);
+        $this->setV1WorkerQueueMessage($v1WorkerQueueMessage);
+
+        return $this;
+    }
+
+    protected function receiveMessage(): Model
+    {
+        return $this->getV1AwsSqsSqsClient()->receiveMessage(
+            [
+                self::QUEUE_URL => $this->getQueueUrl(),
+                self::WAIT_TIME_SECONDS => 20,
+            ]
+        );
+    }
+
+    public function setQueueUrl(string $queueUrl): QueueInterface
+    {
+        if ($this->queueUrl === null) {
+            $this->queueUrl = $queueUrl;
+        } else {
+            throw new \LogicException('Queue URL is already set.');
+        }
+
+        return $this;
+    }
+
+    protected function getQueueUrl(): string
+    {
+        if ($this->queueUrl === null) {
+            throw new \LogicException('Queue URL is not set.');
+        }
+
+        return $this->queueUrl;
+    }
+}

--- a/Function42/src/V1/Worker/Queue.yml
+++ b/Function42/src/V1/Worker/Queue.yml
@@ -1,0 +1,14 @@
+parameters:
+  neighborhoods.v1.worker.queue.queue_url: 'https://sqs.us-east-1.amazonaws.com/272157948465/local-bwilson'
+services:
+  neighborhoods.v1.worker.queue:
+    class: Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue
+    public: true
+    shared: false
+    calls:
+      - [setV1WorkerQueueMessageFactory, ['@neighborhoods.v1.worker.queue.message.factory']]
+      - [setV1AwsSqsSqsClient, ['@v1.aws.sqs.sqs_client']]
+      - [setQueueUrl, ['%neighborhoods.v1.worker.queue.queue_url%']]
+  v1.worker.queue:
+    alias: neighborhoods.v1.worker.queue
+    public: true

--- a/Function42/src/V1/Worker/Queue/Message.php
+++ b/Function42/src/V1/Worker/Queue/Message.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Guzzle;
+use Neighborhoods\KojoFitnessFunction42\V1\Aws;
+
+class Message implements MessageInterface
+{
+    use Guzzle\Service\Resource\Model\AwareTrait;
+    use Aws\Sqs\SqsClient\AwareTrait;
+    protected $isDeleted = false;
+    protected $queueUrl;
+
+    protected const SQS_CLIENT_QUEUE_URL = 'QueueUrl';
+    protected const SQS_CLIENT_RECEIPT_HANDLE = 'ReceiptHandle';
+
+    public function delete(): MessageInterface
+    {
+        if ($this->isDeleted !== false) {
+            throw new \LogicException('Message is already deleted.');
+        }
+        $messages = $this->getGuzzleServiceResourceModel()->get('Messages');
+        $receiptHandle = $messages[0][self::SQS_CLIENT_RECEIPT_HANDLE];
+        $this->getV1AwsSqsSqsClient()->deleteMessage([
+            self::SQS_CLIENT_QUEUE_URL => $this->getQueueUrl(),
+            self::SQS_CLIENT_RECEIPT_HANDLE => $receiptHandle,
+        ]);
+        $this->isDeleted = true;
+
+        return $this;
+    }
+
+    protected function getQueueUrl()
+    {
+        if ($this->queueUrl === null) {
+            throw new \LogicException('Queue URL has not been set.');
+        }
+
+        return $this->queueUrl;
+    }
+
+    public function setQueueUrl($queueUrl): MessageInterface
+    {
+        if ($this->queueUrl !== null) {
+            throw new \LogicException('Queue URL already set.');
+        }
+        $this->queueUrl = $queueUrl;
+
+        return $this;
+    }
+}

--- a/Function42/src/V1/Worker/Queue/Message.yml
+++ b/Function42/src/V1/Worker/Queue/Message.yml
@@ -1,0 +1,11 @@
+services:
+  neighborhoods.v1.worker.queue.message:
+    class: Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\Message
+    public: false
+    shared: false
+    calls:
+      - [setV1AwsSqsSqsClient, ['@v1.aws.sqs.sqs_client']]
+      - [setQueueUrl, ['%neighborhoods.v1.worker.queue.queue_url%']]
+  v1.worker.queue.message:
+    alias: neighborhoods.v1.worker.queue.message
+    public: true

--- a/Function42/src/V1/Worker/Queue/MessageInterface.php
+++ b/Function42/src/V1/Worker/Queue/MessageInterface.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue;
+
+use Guzzle\Service\Resource\Model;
+
+interface MessageInterface
+{
+    public function setGuzzleServiceResourceModel(Model $guzzleServiceResourceModel);
+
+    public function delete(): MessageInterface;
+
+    public function setQueueUrl($queueUrl): MessageInterface;
+}

--- a/Function42/src/V1/Worker/QueueInterface.php
+++ b/Function42/src/V1/Worker/QueueInterface.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1\Worker;
+
+use Neighborhoods\KojoFitnessFunction42\V1\Worker\Queue\MessageInterface;
+
+interface QueueInterface
+{
+    public function getNextMessage(): MessageInterface;
+
+    public function hasNextMessage(): bool;
+
+    public function waitForNextMessage(): QueueInterface;
+}

--- a/Function42/src/V1/WorkerInterface.php
+++ b/Function42/src/V1/WorkerInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\KojoFitnessFunction42\V1;
+
+use Neighborhoods\Kojo\Api\V1\Worker\ServiceInterface;
+
+interface WorkerInterface
+{
+    public function setApiV1WorkerService(ServiceInterface $apiV1WorkerService);
+
+    public function work(): WorkerInterface;
+}


### PR DESCRIPTION
This is a fitness function for https://github.com/neighborhoods/kojo/pull/18.

Here we throw a TypeError and ensure that Kōjō gives us a fighting chance to see what the problem is in the userland `Delegate` code.

Old log message:
```json
{
  "time": "Wed, 10 Oct 18 16:14:27.887391 UTC",
  "level": "critical",
  "process_id": "290",
  "process_path": "/server[282]/root[286]/job[290]",
  "message": "Panicking job with ID[14]."
}
```

New Log Message:

```json
{
  "time": "Wed, 10 Oct 18 16:14:27.887391 UTC",
  "level": "critical",
  "process_id": "290",
  "process_path": "/server[282]/root[286]/job[290]",
  "message": "Panicking job with ID[14]. TypeError: Argument 1 passed to Neighborhoods\\KojoFitnessFunction42\\V1\\Worker\\Delegate::onlyTakesIntegers() must be of the type integer, string given, called in /var/www/html/kojo_fitness.neighborhoods.com/Function42/src/V1/Worker/Delegate.php on line 17}"
}
```

## JIRA
[KOJO-36](https://55places.atlassian.net/browse/KOJO-36)