### PR TITLE
KOJO-73 | Add disabled job type creation to README, and separate bin script for registering it

### DIFF
--- a/UseCase40/README.md
+++ b/UseCase40/README.md
@@ -17,12 +17,13 @@
  docker-compose build --no-cache && docker-compose up -d;
  
  # Create a database
- touch data/pgsql/dumps/kojo_fitness.sql;  
+ touch data/pgsql/dumps/kojo_fitness.sql;
  docker-compose exec pgsql /docker-entrypoint-initdb.d/init.sh;
  
  # Prepare Kōjō
- docker-compose exec kojo_fitness bash -c 'cd UseCase40; composer install';
+ docker-compose exec kojo_fitness bash -c 'cd UseCase40; rm -f composer.lock; composer install';
  docker-compose exec kojo_fitness bash -c 'cd UseCase40; ./vendor/bin/kojo db:setup:install $PWD/src/V1/Environment/';
+ docker-compose exec kojo_fitness bash -c 'cd UseCase40; php ./bin/setup-disabled-worker.php';
  docker-compose exec kojo_fitness bash -c 'cd UseCase40; php ./bin/setup-worker.php';
  
  # Create messages for Kōjō to delete
@@ -32,6 +33,8 @@
  docker-compose exec kojo_fitness bash -c 'cd UseCase40; ./vendor/bin/kojo process:pool:server:start $PWD/src/V1/Environment/' |\
   awk '{ gsub("new_worker", "\033[1;36m&\033[0m"); gsub("working", "\033[1;33m&\033[0m"); gsub("complete_success", "\033[1;32m&\033[0m"); print }';
   
+ # Note: you should not see any instances of the disabled worker in kojo_job
+ 
  # After you see "working" events stop and a few "complete_success" then all messages have been deleted. Press ctrl+c
  
  # Delete the Kōjō Tables and clear redis

--- a/UseCase40/bin/setup-disabled-worker.php
+++ b/UseCase40/bin/setup-disabled-worker.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+error_reporting(E_ALL);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Symfony\Component\Finder\Finder;
+use Neighborhoods\Kojo\Api\V1\Job;
+
+$discoverableDirectories[] = __DIR__ . '/../src/V1/Environment';
+$finder = new Finder();
+$finder->name('*.yml');
+$finder->files()->in($discoverableDirectories);
+$jobCreator = (new Job\Type\Service())->addYmlServiceFinder($finder)->getNewJobTypeRegistrar();
+$jobCreator->setCode('protean_disabled_dlcp_example')
+    ->setWorkerClassUri(\Neighborhoods\KojoFitnessUseCase40\V1\Worker\Facade::class)
+    ->setWorkerMethod('start')
+    ->setName('Protean Disabled DLCP Example')
+    ->setCronExpression('* * * * *')
+    ->setCanWorkInParallel(true)
+    ->setDefaultImportance(10)
+    ->setScheduleLimit(50)
+    ->setScheduleLimitAllowance(1)
+    ->setIsEnabled(false)
+    ->setAutoCompleteSuccess(false)
+    ->setAutoDeleteIntervalDuration('PT0S');
+$jobCreator->save();


### PR DESCRIPTION
UseCase40 now installs another job type that uses the same code as the regular worker, but is disabled. The disabled worker is registered first, so the scheduler will spin attempting to schedule it.

I also added a `rm -f composer.lock` because my UseCase40 was locked to an old kojo version

[Related kojo PR](https://github.com/neighborhoods/kojo/pull/62)